### PR TITLE
Feat: Wallet connect & Mobile Metadata

### DIFF
--- a/wallet.schema.json
+++ b/wallet.schema.json
@@ -136,6 +136,32 @@
         "additionalProperties": false
       }
     },
+    "wallet_connect": {
+      "type": "object",
+      "properties": {
+        "deeplink": {
+          "type": "object",
+          "description": "define all the properties related to deeplink functionality.",
+          "properties": {
+            "path": {
+              "type": "object",
+              "description": "it is the path of the deelink URL that will trigger wallet connect actions within a mobile wallet.",
+              "properties": {
+                "ios": {
+                  "type": "string"
+                },
+                "android": {
+                  "type": "string"
+                },
+                "universal": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "mobile": {
       "type": "object",
       "properties": {
@@ -149,6 +175,10 @@
             "schema": {
               "type": "string",
               "description": "Custom schema that provide a way to reference resources inside an app, documented [here](https://developer.android.com/training/app-links/deep-linking)."
+            },
+            "universalSchema": {
+              "type": "string",
+              "description": "Universal schema for universal deeplink that provide a way to reference resources inside an app, documented [here](https://developer.android.com/training/app-links)."
             }
           }
         },
@@ -162,6 +192,10 @@
             "schema": {
               "type": "string",
               "description": "Custom URL schemes provide a way to reference resources inside an app, documented [here](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app)."
+            },
+            "universalSchema": {
+              "type": "string",
+              "description": "Universal schema for universal deeplink that provide a way to reference resources inside an app, documented [here](https://developer.apple.com/ios/universal-links/)."
             }
           }
         }

--- a/wallet.schema.json
+++ b/wallet.schema.json
@@ -135,6 +135,37 @@
         "required": ["layout"],
         "additionalProperties": false
       }
+    },
+    "mobile": {
+      "type": "object",
+      "properties": {
+        "android": {
+          "type": "object",
+          "properties": {
+            "packageName": {
+              "type": "string",
+              "description": "The package name for your Android standalone app. You make it up, but it needs to be unique on the Play Store. See this [StackOverflow question](https://stackoverflow.com/questions/6273892/android-package-name-convention)."
+            },
+            "schema": {
+              "type": "string",
+              "description": "Custom schema that provide a way to reference resources inside an app, documented [here](https://developer.android.com/training/app-links/deep-linking)."
+            }
+          }
+        },
+        "ios": {
+          "type": "object",
+          "properties": {
+            "bundleIdentifier": {
+              "type": "string",
+              "description": "The bundle identifier for your iOS standalone app. You make it up, but it needs to be unique on the App Store. See this [StackOverflow question](https://stackoverflow.com/questions/11347470/what-does-bundle-identifier-mean-in-an-ios-project)."
+            },
+            "schema": {
+              "type": "string",
+              "description": "Custom URL schemes provide a way to reference resources inside an app, documented [here](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app)."
+            }
+          }
+        }
+      }
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
the goal of this PR is to add the mobile metadata of a wallet and also its definitions for wallet connect, such as the patterns with which a user can invoke the service on mobile