### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+** @cosmos/stack-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-** @cosmos/stack-team
+** @cosmos/ecosystem-team


### PR DESCRIPTION
Adds `.github/CODEOWNERS` to assign `@cosmos/ecosystem-team` as code owners for all files.